### PR TITLE
Fix missing Chinese character display

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -150,6 +150,7 @@ article.post #disqus_thread .row {
   width: 100px;
   color: #ff3333;
   content: '碼';
+  font-family: 'Noto Sans SC', 'Microsoft YaHei', 'SimSun', 'STHeiti', 'PingFang SC', sans-serif;
   font-size: 70px;
   height: 100px;
   margin-top: calc(-100px / 2 - 20px);

--- a/assets/less/_util.less
+++ b/assets/less/_util.less
@@ -58,6 +58,7 @@
         .circle-image(@color, @character-height);
         color: @color;
         content: @content;
+        font-family: 'Noto Sans SC', 'Microsoft YaHei', 'SimSun', 'STHeiti', 'PingFang SC', sans-serif;
         font-size: @character-height - 30;
         height: @character-height;
         margin-top: calc(-@character-height / 2 - @character-padding);


### PR DESCRIPTION
Added explicit font-family declaration to the .chinese-character mixin to ensure proper rendering of the Chinese character '碼' (code) that appears as a decorative element on code blocks.

The font stack includes common Chinese-supporting fonts:
- Noto Sans SC (Google's CJK font)
- Microsoft YaHei (Windows)
- SimSun (Windows)
- STHeiti (macOS)
- PingFang SC (macOS)
- sans-serif fallback

This prevents the character from inheriting Roboto font which doesn't have Chinese glyphs, ensuring the decorative element displays correctly across different browsers and operating systems.