### PR TITLE
Enable word wrapping in code blocks

### DIFF
--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -197,9 +197,7 @@ article.post #disqus_thread .row {
 .highlight pre code {
   display: block;
   overflow-x: auto;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  word-break: break-word;
+  white-space: pre;
   font-size: 0.95rem;
 }
 .highlight pre .k,
@@ -220,6 +218,11 @@ article.post #disqus_thread .row {
 }
 .highlight pre .nt {
   color: #ff3333;
+}
+.highlight.language-markdown pre code {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-word;
 }
 /**
  * This less file contains the colors used in the site.

--- a/assets/less/_code.less
+++ b/assets/less/_code.less
@@ -18,9 +18,7 @@
         code {
             display: block;
             overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            word-break: break-word;
+            white-space: pre;
             font-size: 0.95rem;
         }
 
@@ -43,5 +41,12 @@
         .nt {
             color: @contrast;
         }
+    }
+
+    // Enable word wrapping only for markdown code blocks (AI prompts)
+    &.language-markdown pre code {
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        word-break: break-word;
     }
 }


### PR DESCRIPTION
- Regular code blocks (JavaScript, Python, etc.) now use single-line format with horizontal scrolling
- Markdown code blocks (used for AI prompts) retain word wrapping for better readability
- This differentiates AI prompts in the Harry Potter blog post from actual code examples